### PR TITLE
setting mergemode to insert to avoid multiple concurring executions

### DIFF
--- a/manifests/path_element.pp
+++ b/manifests/path_element.pp
@@ -20,7 +20,7 @@ define environment_variable::path_element(
         ensure    => $ensure,
         variable  => 'PATH',
         value     => $path,
-        mergemode => prepend,
+        mergemode => insert,
       }
     }
 


### PR DESCRIPTION
Changed mergemode to insert for windows path_element resource. Otherwise you will get competing resources as soon as two path_element resources are set. Both want to be in the first place and change this one after another.